### PR TITLE
Allow any fasta file to be valid input

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,5 +15,5 @@ dependencies:
     - git+https://github.com/cov-ert/clusterfunk.git@v0.0.1
     - pytools==2020.1
     - dendropy>=4.4.0
-    - git+https://github.com/aineniamh/lineages.git
+    - git+https://github.com/aunderwo/lineages.git
 

--- a/pangolin/scripts/assign_lineage.py
+++ b/pangolin/scripts/assign_lineage.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import argparse
 
 from lineage_finder import LineageFinder

--- a/pangolin/scripts/assign_query_file.smk
+++ b/pangolin/scripts/assign_query_file.smk
@@ -29,9 +29,11 @@ rule pass_query_hash:
             for record in SeqIO.parse(input[0],"fasta"):
                 c+=1
                 record_list = record.id.split('|')
-                lineage = record_list[2]
-                
-                new_id = f"{c}_{lineage}"
+                if len(record_list) >= 3:
+                    lineage = record_list[2]
+                    new_id = f"{c}_{lineage}"
+                else:
+                    new_id = f"{c}"
 
                 fkey.write(f"{record.id},{new_id}\n")
                 fw.write(f">{new_id}\n{record.seq}\n")

--- a/pangolin/scripts/assign_query_file.smk
+++ b/pangolin/scripts/assign_query_file.smk
@@ -23,7 +23,7 @@ rule pass_query_hash:
         key = temp(config["outdir"] + "/temp/query_key.csv")
     run:
         fkey = open(output.key, "w")
-        ids = ''
+        ids = []
         c= 0
         with open(output.fasta, "w") as fw:
             for record in SeqIO.parse(input[0],"fasta"):
@@ -33,17 +33,16 @@ rule pass_query_hash:
                     lineage = record_list[2]
                     new_id = f"{c}_{lineage}"
                 else:
-                    new_id = str(c)
+                    new_id = f"{c}"
 
                 fkey.write(f"{record.id},{new_id}\n")
                 fw.write(f">{new_id}\n{record.seq}\n")
 
-                ids+=new_id + ','
+                ids.append(new_id)
             
             print(f"{c+1} hashed sequences written")
         fkey.close()
         
-        ids = ids.rstrip(',')
         query_sequence.store("query_store",ids)
         shell("touch {output.t}")
 
@@ -65,7 +64,7 @@ rule assign_lineages:
         report = config["outdir"] + "/lineage_report.csv"
     run:
         query_sequences = query_sequence.fetch("query_store")
-        num_query_seqs = len(query_sequences.split(","))
+        num_query_seqs = len(query_sequences)
         if query_sequences != "":
             print(f"Passing {num_query_seqs} into processing pipeline.")
             config["query_sequences"]= query_sequences

--- a/pangolin/scripts/assign_query_file.smk
+++ b/pangolin/scripts/assign_query_file.smk
@@ -33,7 +33,7 @@ rule pass_query_hash:
                     lineage = record_list[2]
                     new_id = f"{c}_{lineage}"
                 else:
-                    new_id = f"{c}"
+                    new_id = str(c)
 
                 fkey.write(f"{record.id},{new_id}\n")
                 fw.write(f">{new_id}\n{record.seq}\n")

--- a/pangolin/scripts/assign_query_lineage.smk
+++ b/pangolin/scripts/assign_query_lineage.smk
@@ -6,8 +6,6 @@ if config.get("outdir"):
 else:
     config["outdir"] = "analysis"
 
-config["query_sequences"]=[i for i in config["query_sequences"].split(',')]
-
 rule all:
     input:
         config["outdir"] + "/lineage_report.csv"


### PR DESCRIPTION
This code means that if a fasta file doesn't have the | character splitting the id (e.g download from GISAID where the id is >hCoV-19/Scotland/CVR10/2020|EPI_ISL_415631 ) , it will still be processed.